### PR TITLE
Macros of!, empty! and from_iter! replaced by functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased](https://github.com/M-Adoo/rxRust/compare/v0.3.0...HEAD)
 
+### Breaking Changes
+- **observable**: macros `of!`, `empty!`, `from_iter!`, `from_future!` and
+  `from_future_with_errors!` replaced by functions.
+
 ## [0.4.0](https://github.com/M-Adoo/rxRust/releases/tag/v0.4.0)  (2019-11-07)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -66,13 +66,13 @@ observable::from_iter(0..10)
 
 ## Converts from a Future
 
-just use `observable::from_future!` to convert a `Future` to an observable sequence.
+just use `observable::from_future` to convert a `Future` to an observable sequence.
 
 ```rust
 use rxrust::prelude::*;
 use futures::future;
 
-observable::from_future!(future::ready(1))
+observable::from_future(future::ready(1))
   .subscribe(move |v| println!("subscribed with {}", v));
 
 // because all future in rxrust are execute async, so we wait a second to see

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ observable::from_future(future::ready(1))
 std::thread::sleep(std::time::Duration::new(1, 0));
 ```
 
-A `from_future_with_err！` macro also provided to propagating error from `Future`.
+A `from_future_with_err` function also provided to propagating error from `Future`.
 
 ## All contributions are welcome
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ use rxrust::{
   ops::{ Filter, Merge, Fork }, prelude::*, 
 };
 
-let mut numbers = observable::from_iter!(0..10);
+let mut numbers = observable::from_iter(0..10);
 // crate a even stream by filter
 let even = numbers.fork().filter(|v| *v % 2 == 0);
 // crate an odd stream by filter
@@ -36,7 +36,7 @@ In `rxrust` almost all extensions consume the upstream. So when you try to subsc
 
 ```rust ignore
  # use rxrust::prelude::*;
- let o = observable::from_iter!(0..10);
+ let o = observable::from_iter(0..10);
  o.subscribe(|_| {println!("consume in first")});
  o.subscribe(|_| {println!("consume in second")});
 ```
@@ -46,7 +46,7 @@ In this case, we can use `Fork` to fork a stream. In general, `Fork` has same me
 ```rust
  # use rxrust::prelude::*;
  # use rxrust::ops::Fork;
- let o = observable::from_iter!(0..10);
+ let o = observable::from_iter(0..10);
  o.fork().subscribe(|_| {println!("consume in first")});
  o.fork().subscribe(|_| {println!("consume in second")});
 ```
@@ -57,7 +57,7 @@ In this case, we can use `Fork` to fork a stream. In general, `Fork` has same me
 use rxrust::prelude::*;
 use rxrust::{ops::{ ObserveOn, SubscribeOn, Map }, scheduler::Schedulers };
 
-observable::from_iter!(0..10)
+observable::from_iter(0..10)
   .subscribe_on(Schedulers::NewThread)
   .map(|v| *v*2)
   .observe_on(Schedulers::NewThread)

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -211,13 +211,13 @@ mod test {
 
   #[test]
   fn fork_and_share() {
-    let observable = observable::empty!();
+    let observable = observable::empty();
     // shared after fork
     observable.fork().to_shared().subscribe(|_: &()| {});
     observable.fork().to_shared().subscribe(|_| {});
 
     // shared before fork
-    let observable = observable::empty!().to_shared();
+    let observable = observable::empty().to_shared();
     observable.fork().subscribe(|_: &()| {});
     observable.fork().subscribe(|_| {});
   }

--- a/src/observable/connectable_observable.rs
+++ b/src/observable/connectable_observable.rs
@@ -152,7 +152,7 @@ mod test {
 
   #[test]
   fn smoke() {
-    let o = observable::of!(100);
+    let o = observable::of(100);
     let connected = LocalConnectableObservable::local(o);
     let mut first = 0;
     let mut second = 0;
@@ -166,7 +166,7 @@ mod test {
 
   #[test]
   fn fork_and_shared() {
-    let o = observable::of!(100);
+    let o = observable::of(100);
     let connected = LocalConnectableObservable::local(o).to_shared();
     connected.fork().subscribe(|_| {});
     connected.fork().subscribe(|_| {});

--- a/src/observable/from.rs
+++ b/src/observable/from.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports)]
 use crate::prelude::*;
 
 pub fn from_iter<O, U, Iter>(

--- a/src/observable/from_future.rs
+++ b/src/observable/from_future.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports)]
 use crate::prelude::*;
 use futures::{
   executor::ThreadPool, future::Future, future::FutureExt, task::SpawnExt,

--- a/src/ops/delay.rs
+++ b/src/ops/delay.rs
@@ -68,7 +68,7 @@ fn smoke() {
   use std::sync::{Arc, Mutex};
   let value = Arc::new(Mutex::new(0));
   let c_value = value.clone();
-  observable::of!(1)
+  observable::of(1)
     .delay(Duration::from_millis(50))
     .subscribe(move |v| {
       *value.lock().unwrap() = *v;

--- a/src/ops/filter.rs
+++ b/src/ops/filter.rs
@@ -10,7 +10,7 @@ use ops::SharedOp;
 /// let mut coll = vec![];
 /// let coll_clone = coll.clone();
 ///
-/// observable::from_iter!(0..10)
+/// observable::from_iter(0..10)
 ///   .filter(|v| *v % 2 == 0)
 ///   .subscribe(|v| { coll.push(*v); });
 
@@ -126,7 +126,7 @@ mod test {
 
   #[test]
   fn fork_and_shared() {
-    observable::from_iter!(0..10)
+    observable::from_iter(0..10)
       .filter(|v| v % 2 == 0)
       .fork()
       .to_shared()

--- a/src/ops/first.rs
+++ b/src/ops/first.rs
@@ -128,7 +128,7 @@ mod test {
     let mut completed = 0;
     let mut next_count = 0;
 
-    observable::from_iter!(0..2)
+    observable::from_iter(0..2)
       .first()
       .subscribe_complete(|_| next_count += 1, || completed += 1);
 
@@ -141,7 +141,7 @@ mod test {
     let mut completed = false;
     let mut next_count = 0;
 
-    observable::from_iter!(0..2)
+    observable::from_iter(0..2)
       .first_or(100)
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
@@ -150,7 +150,7 @@ mod test {
 
     completed = false;
     let mut v = 0;
-    observable::empty!()
+    observable::empty()
       .first_or(100)
       .subscribe_complete(|value| v = *value, || completed = true);
 
@@ -162,11 +162,13 @@ mod test {
   fn first_support_fork() {
     let mut value = 0;
     let mut value2 = 0;
-    let o = observable::from_iter!(1..100).first();
-    let o1 = o.fork().first();
-    let o2 = o.fork().first();
-    o1.subscribe(|v| value = *v);
-    o2.subscribe(|v| value2 = *v);
+    {
+      let o = observable::from_iter(1..100).first();
+      let o1 = o.fork().first();
+      let o2 = o.fork().first();
+      o1.subscribe(|v| value = *v);
+      o2.subscribe(|v| value2 = *v);
+    }
     assert_eq!(value, 1);
     assert_eq!(value2, 1);
   }
@@ -188,7 +190,7 @@ mod test {
 
   #[test]
   fn fork_and_shared() {
-    observable::of!(0)
+    observable::of(0)
       .first_or(0)
       .fork()
       .fork()
@@ -197,7 +199,7 @@ mod test {
       .to_shared()
       .subscribe(|_| {});
 
-    observable::of!(0)
+    observable::of(0)
       .first()
       .fork()
       .fork()

--- a/src/ops/fork.rs
+++ b/src/ops/fork.rs
@@ -3,13 +3,13 @@
 /// # Example
 /// ```rust ignore
 ///  # use rxrust::prelude::*;
-///  let o = observable::from_iter!(0..10);
+///  let o = observable::from_iter(0..10);
 ///  o.subscribe_err(|_| {println!("consume in first")}, |_:&()|{});
 ///  o.subscribe_err(|_| {println!("consume in second")}, |_:&()|{});
 /// ```
 /// it will compile failed, complains like this:
 /// ```shell
-// 5 |  let o = observable::from_iter!(0..10);
+// 5 |  let o = observable::from_iter(0..10);
 //   |      - move occurs because `o` has type `rxrust::observable::Observable`,
 //   |        which does not implement the `Copy` trait
 // 6 |  o.subscribe_err(|_| {println!("consume in first")}, |_:&()|{});
@@ -23,7 +23,7 @@
 /// ```rust
 ///  # use rxrust::prelude::*;
 ///  # use rxrust::ops::Fork;
-///  let o = observable::from_iter!(0..10);
+///  let o = observable::from_iter(0..10);
 ///  o.fork().subscribe_err(|_| {println!("consume in first")}, |_:&()|{});
 ///  o.fork().subscribe_err(|_| {println!("consume in second")}, |_:&()|{});
 /// ```

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -209,7 +209,7 @@ mod test {
   #[test]
   fn primitive_type() {
     let mut i = 0;
-    observable::from_iter!(100..101)
+    observable::from_iter(100..101)
       .map(|v| v * 2)
       .subscribe(|v| i += *v);
     assert_eq!(i, 200);
@@ -219,7 +219,7 @@ mod test {
   fn reference_lifetime_should_work() {
     let mut i = 0;
 
-    observable::of!(100)
+    observable::of(100)
       .map_return_ref(|v| v)
       .subscribe(|v| i += *v);
     assert_eq!(i, 100);
@@ -228,7 +228,7 @@ mod test {
   #[test]
   fn fork_and_shared() {
     // type to type can fork
-    let m = observable::from_iter!(0..100).map(|v| *v);
+    let m = observable::from_iter(0..100).map(|v| *v);
     m.fork()
       .map(|v| *v)
       .fork()
@@ -238,7 +238,7 @@ mod test {
       .subscribe(|_| {});
 
     // ref to ref can fork
-    let m = observable::from_iter!(0..100).map_return_ref(|v| v);
+    let m = observable::from_iter(0..100).map_return_ref(|v| v);
     m.fork()
       .map_return_ref(|v| v)
       .fork()

--- a/src/ops/merge.rs
+++ b/src/ops/merge.rs
@@ -338,8 +338,8 @@ mod test {
   #[test]
   fn merge_local_and_shared() {
     let mut res = vec![];
-    let shared = observable::of!(1);
-    let local = observable::of!(2);
+    let shared = observable::of(1);
+    let local = observable::of(2);
 
     shared.merge(local).to_shared().subscribe(move |v| {
       res.push(*v);

--- a/src/ops/observe_on.rs
+++ b/src/ops/observe_on.rs
@@ -176,7 +176,7 @@ mod test {
   fn unsubscribe_scheduler(scheduler: Schedulers) {
     let emitted = Arc::new(Mutex::new(vec![]));
     let c_emitted = emitted.clone();
-    observable::from_iter!(0..10)
+    observable::from_iter(0..10)
       .observe_on(scheduler)
       .delay(Duration::from_millis(10))
       .subscribe(move |v| {

--- a/src/ops/publish.rs
+++ b/src/ops/publish.rs
@@ -22,7 +22,7 @@ impl<'a, Item, Err, T> Publish<'a, Item, Err> for T {}
 #[test]
 fn smoke() {
   use crate::observable::Connect;
-  let p = observable::of!(100).publish();
+  let p = observable::of(100).publish();
   let mut first = 0;
   let mut second = 0;
   p.fork().subscribe(|v| first = *v);

--- a/src/ops/ref_count.rs
+++ b/src/ops/ref_count.rs
@@ -255,7 +255,7 @@ fn smoke() {
   let mut accept1 = 0;
   let mut accept2 = 0;
   {
-    let ref_count = observable::of!(1).fork().publish().ref_count();
+    let ref_count = observable::of(1).fork().publish().ref_count();
     ref_count.fork().subscribe(|v| accept1 = *v);
     ref_count.fork().subscribe(|v| accept2 = *v);
   }
@@ -287,7 +287,7 @@ fn auto_unsubscribe() {
 #[test]
 fn fork_and_shared() {
   use crate::ops::Publish;
-  observable::of!(1).publish().ref_count().subscribe(|_| {});
+  observable::of(1).publish().ref_count().subscribe(|_| {});
 
   LocalSubject::<'_, (), ()>::local()
     .publish()
@@ -295,18 +295,18 @@ fn fork_and_shared() {
     .to_shared()
     .subscribe(|_| {});
 
-  observable::of!(1)
+  observable::of(1)
     .publish()
     .to_shared()
     .ref_count()
     .subscribe(|_| {});
 
-  observable::of!(1)
+  observable::of(1)
     .publish()
     .to_shared()
     .ref_count()
     .subscribe(|_| {});
-  observable::of!(1)
+  observable::of(1)
     .publish()
     .to_shared()
     .ref_count()

--- a/src/ops/subscribe_on.rs
+++ b/src/ops/subscribe_on.rs
@@ -15,8 +15,8 @@ use crate::scheduler::Scheduler;
 /// use rxrust::prelude::*;
 /// use rxrust::ops::{ Merge };
 ///
-/// let a = observable::from_iter!(1..5);
-/// let b = observable::from_iter!(5..10);
+/// let a = observable::from_iter(1..5);
+/// let b = observable::from_iter(5..10);
 /// a.merge(b).subscribe(|v| print!("{} ", *v));
 /// ```
 ///
@@ -32,8 +32,8 @@ use crate::scheduler::Scheduler;
 /// use rxrust::ops::{ Merge, SubscribeOn };
 /// use std::thread;
 ///
-/// let a = observable::from_iter!(1..5).subscribe_on(Schedulers::NewThread);
-/// let b = observable::from_iter!(5..10);
+/// let a = observable::from_iter(1..5).subscribe_on(Schedulers::NewThread);
+/// let b = observable::from_iter(5..10);
 /// a.merge(b).to_shared().subscribe(|v|{
 ///   let handle = thread::current();
 ///   print!("{}({:?}) ", *v, handle.id())
@@ -111,7 +111,7 @@ mod test {
     let c_res = res.clone();
     let thread = Arc::new(Mutex::new(vec![]));
     let c_thread = thread.clone();
-    observable::from_iter!(1..5)
+    observable::from_iter(1..5)
       .subscribe_on(Schedulers::NewThread)
       .subscribe(move |v| {
         res.lock().unwrap().push(*v);
@@ -136,7 +136,7 @@ mod test {
   fn unsubscribe_scheduler(scheduler: Schedulers) {
     let emitted = Arc::new(Mutex::new(vec![]));
     let c_emitted = emitted.clone();
-    observable::from_iter!(0..10)
+    observable::from_iter(0..10)
       .subscribe_on(scheduler)
       .delay(Duration::from_millis(10))
       .subscribe(move |v| {

--- a/src/ops/take.rs
+++ b/src/ops/take.rs
@@ -15,7 +15,7 @@ use crate::prelude::*;
 ///   ops::{Take}, prelude::*,
 /// };
 ///
-/// observable::from_iter!(0..10).take(5).subscribe(|v| println!("{}", v));
+/// observable::from_iter(0..10).take(5).subscribe(|v| println!("{}", v));
 ///
 
 /// // print logs:
@@ -146,7 +146,7 @@ mod test {
     let mut completed = false;
     let mut next_count = 0;
 
-    observable::from_iter!(0..100)
+    observable::from_iter(0..100)
       .take(5)
       .subscribe_complete(|_| next_count += 1, || completed = true);
 
@@ -158,19 +158,21 @@ mod test {
   fn take_support_fork() {
     let mut nc1 = 0;
     let mut nc2 = 0;
-    let take5 = observable::from_iter!(0..100).take(5);
-    let f1 = take5.fork();
-    let f2 = take5.fork();
-    f1.take(5).fork().subscribe(|_| nc1 += 1);
-    f2.take(5).fork().subscribe(|_| nc2 += 1);
+    {
+      let take5 = observable::from_iter(0..100).take(5);
+      let f1 = take5.fork();
+      let f2 = take5.fork();
 
+      f1.take(5).fork().subscribe(|_| nc1 += 1);
+      f2.take(5).fork().subscribe(|_| nc2 += 1);
+    }
     assert_eq!(nc1, 5);
     assert_eq!(nc2, 5);
   }
 
   #[test]
   fn into_shared() {
-    observable::from_iter!(0..100)
+    observable::from_iter(0..100)
       .take(5)
       .take(5)
       .to_shared()

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -216,7 +216,7 @@ fn smoke() {
 
 #[test]
 fn fork_and_shared() {
-  observable::of!(0..10)
+  observable::of(0..10)
     .throttle_time(Duration::from_nanos(1), ThrottleEdge::Leading)
     .fork()
     .to_shared()

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -78,7 +78,7 @@ mod test {
 
   fn sum_of_sqrt(scheduler: Schedulers) {
     let sum = Arc::new(Mutex::new(0.));
-    observable::from_iter!(0..10)
+    observable::from_iter(0..10)
       .observe_on(scheduler)
       .subscribe(move |v| {
         *sum.lock().unwrap() =


### PR DESCRIPTION
I'm proposing a change that (partially) addresses #23 and replaces macros with plain strongly typed and constrained functions.
Hope you'll find it useful for further development.
