### PR TITLE
New trivial observables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 - **operator**: add `scan` operator.
-- **operator**: add trivial `throw`, `empty` and `never` operators.
+- **observable**: add trivial `throw`, `empty`, `never` and `repeat` observables.
 
 ### Bug Fixes
 - **operator**: fix the compiler complain when `map` operator convert source type to a different one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 - **operator**: add `scan` operator.
+- **operator**: add trivial `throw`, `empty` and `never` operators.
 
 ### Bug Fixes
 - **operator**: fix the compiler complain when `map` operator convert source type to a different one.

--- a/src/observable.rs
+++ b/src/observable.rs
@@ -1,5 +1,7 @@
 use crate::prelude::*;
 
+mod trivial;
+pub use trivial::*;
 mod from;
 pub use from::*;
 pub(crate) mod from_future;

--- a/src/observable/from.rs
+++ b/src/observable/from.rs
@@ -1,5 +1,29 @@
 use crate::prelude::*;
 
+/// Creates an observable that produces values from an iterator.
+///
+/// Completes when all elements have been emitted. Never emits an error.
+///
+/// # Examples
+///
+/// A simple example for a range:
+///
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::from_iter(0..10)
+///   .subscribe(|v| {println!("{},", v)});
+/// ```
+///
+/// Or with a vector:
+///
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::from_iter(vec![0,1,2,3])
+///   .subscribe(|v| {println!("{},", v)});
+/// ```
+///
 pub fn from_iter<O, U, Iter>(
   iter: Iter,
 ) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
@@ -22,6 +46,19 @@ where
   })
 }
 
+/// Creates an observable producing a single value.
+///
+/// Completes immediatelly after emitting the value given. Never emits an error.
+///
+/// # Examples
+///
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::of(123)
+///   .subscribe(|v| {println!("{},", v)});
+/// ```
+///
 pub fn of<O, U, Item>(
   v: Item,
 ) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
@@ -36,6 +73,106 @@ where
   })
 }
 
+/// Creates an observable that emits no items and terminates with an error.
+pub fn throw<O, U, Item, Err>(
+  v: Err,
+) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, Err>,
+  U: SubscriptionLike,
+  Err: Clone,
+  Item: Clone,
+{
+  Observable::new(move |mut subscriber| {
+    subscriber.error(&v);
+  })
+}
+
+/// Creates an observable that emits result's value provided by [`Result`] or the error.
+/// 
+/// Completes immediatelly after.
+/// 
+/// # Examples 
+///
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::of_result(Ok(1234))
+///   .subscribe(|v| {println!("{},", v)});
+/// ```
+///
+/// ```
+/// observable::of_result(Err("An error"))
+///   .subscribe(|v| {println!("{},", v)});
+/// 
+/// // result: nothing printed
+/// ```
+/// 
+pub fn of_result<O, U, Item,Err>(
+  r: Result<Item, Err>,
+) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, Err>,
+  U: SubscriptionLike,
+  Item: Clone,
+  Err: Clone,
+{
+  Observable::new(move |mut subscriber| {
+    match &r
+    {
+      Ok(v) => subscriber.next(v),
+      Err(e) => subscriber.error(e),
+    };
+    subscriber.complete();
+  })
+}
+
+/// Creates an observable that potentially emits a single value from [`Option`].
+/// 
+/// Emits the value if is there, and completes immediatelly after. When given option
+/// has not value, completes immediatelly. Never emitts an error.
+/// 
+/// # Examples 
+///
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::of_result(Some(1234))
+///   .subscribe(|v| {println!("{},", v)});
+/// ```
+/// 
+pub fn of_option<O, U, Item>(
+  o: Option<Item>,
+) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, ()>,
+  U: SubscriptionLike,
+  Item: Clone,
+{
+  Observable::new(move |mut subscriber| {
+    match &o
+    {
+      Some(v) => subscriber.next(v),
+      None => ()
+    };
+    subscriber.complete();
+  })
+}
+
+/// Creates an observable that produces no values.
+///
+/// Completes immediatelly. Never emits an error.
+///
+/// # Examples
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::empty()
+///   .subscribe(|v| {println!("{},", v)});
+///
+/// // Result: no thing printed
+/// ```
+/// 
 pub fn empty<O, U, Item>() -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
 where
   O: Observer<Item, ()>,
@@ -44,6 +181,50 @@ where
   Observable::new(move |mut subscriber: Subscriber<O, U>| {
     subscriber.complete();
   })
+}
+
+/// Creates an observable that never emitts any value and never completes.
+///
+/// Neither emitts an error.
+///
+pub fn never<O, U, Item>() -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, ()>,
+  U: SubscriptionLike,
+{
+  Observable::new(move |_subscriber: Subscriber<O, U>| {
+    loop {
+      // will not complete
+    }
+  })
+}
+
+/// Creates an observable that emits the return value of a function-like callable.
+/// 
+/// Never emits an error
+/// 
+/// # Examples
+/// 
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::start(|| {1234})
+///   .subscribe(|v| {println!("{},", v)});
+/// ```
+/// 
+pub fn start<O, U, Callable, Item>(
+  func: Callable,
+) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  Callable: FnOnce() -> Item,
+  O: Observer<Item, ()>,
+  U: SubscriptionLike,
+  Item: Clone,
+{
+  // because of Rust zero-cost abstraction
+  // we can compose from what we have already
+  // without fearing of introducing unwanted overhead
+  of(func())
 }
 
 #[cfg(test)]

--- a/src/observable/from.rs
+++ b/src/observable/from.rs
@@ -81,6 +81,41 @@ where
   })
 }
 
+/// Creates an observable producing same value repeated N times.
+///
+/// Completes immediatelly after emitting N values. Never emits an error.
+///
+/// # Arguments
+///
+/// * `v` - A value to emitt.
+/// * `n` - A number of time to repeat it.
+///
+/// # Examples
+///
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::repeat(123, 3)
+///   .subscribe(|v| {println!("{},", v)});
+///
+/// // print log:
+/// // 123
+/// // 123
+/// // 123
+/// ```
+///
+pub fn repeat<O, U, Item>(
+  v: Item,
+  n: usize,
+) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, ()>,
+  U: SubscriptionLike,
+  Item: Clone,
+{
+  from_iter(std::iter::repeat(v).take(n))
+}
+
 /// Creates an observable that emits value or the error from a [`Result`] given.
 ///
 /// Completes immediatelly after.
@@ -303,5 +338,35 @@ mod test {
       .subscribe(|_| {});
 
     observable::of(0).fork().fork().subscribe(|_| {});
+  }
+
+  #[test]
+  fn repeat_three_times() {
+    let mut hit_count = 0;
+    let mut completed = false;
+    observable::repeat(123, 5).subscribe_complete(
+      |v| {
+        hit_count += 1;
+        assert_eq!(123, *v);
+      },
+      || completed = true,
+    );
+    assert_eq!(5, hit_count);
+    assert!(completed);
+  }
+
+  #[test]
+  fn repeat_zero_times() {
+    let mut hit_count = 0;
+    let mut completed = false;
+    observable::repeat(123, 0).subscribe_complete(
+      |v| {
+        hit_count += 1;
+        assert_eq!(123, *v);
+      },
+      || completed = true,
+    );
+    assert_eq!(0, hit_count);
+    assert!(completed);
   }
 }

--- a/src/observable/from.rs
+++ b/src/observable/from.rs
@@ -4,6 +4,10 @@ use crate::prelude::*;
 ///
 /// Completes when all elements have been emitted. Never emits an error.
 ///
+/// # Arguments
+///
+/// * `iter` - An iterator to get all the values from.
+///
 /// # Examples
 ///
 /// A simple example for a range:
@@ -50,6 +54,10 @@ where
 ///
 /// Completes immediatelly after emitting the value given. Never emits an error.
 ///
+/// # Arguments
+///
+/// * `v` - A value to emitt.
+///
 /// # Examples
 ///
 /// ```
@@ -76,6 +84,10 @@ where
 /// Creates an observable that emits value or the error from a [`Result`] given.
 ///
 /// Completes immediatelly after.
+///
+/// # Arguments
+///
+/// * `r` - A [`Result`] argument to take a value, or an error to emitt from.
 ///
 /// # Examples
 ///
@@ -116,6 +128,10 @@ where
 /// Emits the value if is there, and completes immediatelly after. When the
 /// given option has not value, completes immediatelly. Never emitts an error.
 ///
+/// # Arguments
+///
+/// * `o` - An optional used to take a value to emitt from.
+///
 /// # Examples
 ///
 /// ```
@@ -144,7 +160,11 @@ where
 
 /// Creates an observable that emits the return value of a callable.
 ///
-/// Never emits an error
+/// Never emits an error.
+///
+/// # Arguments
+///
+/// * `f` - A function that will be called to obtain its return value to emitt.
 ///
 /// # Examples
 ///
@@ -156,7 +176,7 @@ where
 /// ```
 ///
 pub fn from_fn<O, U, Callable, Item>(
-  callable: Callable,
+  f: Callable,
 ) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
 where
   Callable: FnOnce() -> Item,
@@ -166,7 +186,7 @@ where
 {
   // Because of Rust zero-cost abstraction we can compose from
   // what we already have without a fear of too much overhead added.
-  of(callable())
+  of(f())
 }
 
 #[cfg(test)]

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -2,8 +2,13 @@
 use crate::prelude::*;
 
 /// Creates an observable that emitts no items, just terminates with an error.
+///
+/// # Arguments
+///
+/// * `e` - An error to emitt and terminate with
+///
 pub fn throw<O, U, Item, Err>(
-  v: Err,
+  e: Err,
 ) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
 where
   O: Observer<Item, Err>,
@@ -12,7 +17,7 @@ where
   Item: Clone,
 {
   Observable::new(move |mut subscriber| {
-    subscriber.error(&v);
+    subscriber.error(&e);
   })
 }
 

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -1,4 +1,3 @@
-#![allow(unused_imports)]
 use crate::prelude::*;
 
 /// Creates an observable that emitts no items, just terminates with an error.

--- a/src/observable/trivial.rs
+++ b/src/observable/trivial.rs
@@ -1,0 +1,90 @@
+#![allow(unused_imports)]
+use crate::prelude::*;
+
+/// Creates an observable that emitts no items, just terminates with an error.
+pub fn throw<O, U, Item, Err>(
+  v: Err,
+) -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, Err>,
+  U: SubscriptionLike,
+  Err: Clone,
+  Item: Clone,
+{
+  Observable::new(move |mut subscriber| {
+    subscriber.error(&v);
+  })
+}
+
+/// Creates an observable that produces no values.
+///
+/// Completes immediatelly. Never emits an error.
+///
+/// # Examples
+/// ```
+/// use rxrust::prelude::*;
+///
+/// observable::empty()
+///   .subscribe(|v: &i32| {println!("{},", v)});
+///
+/// // Result: no thing printed
+/// ```
+///
+pub fn empty<O, U, Item>() -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, ()>,
+  U: SubscriptionLike,
+{
+  Observable::new(move |mut subscriber: Subscriber<O, U>| {
+    subscriber.complete();
+  })
+}
+
+/// Creates an observable that never emitts anything.
+///
+/// Neither emitts a value, nor completes, nor emitts an error.
+///
+pub fn never<O, U, Item>() -> Observable<impl FnOnce(Subscriber<O, U>) + Clone>
+where
+  O: Observer<Item, ()>,
+  U: SubscriptionLike,
+{
+  Observable::new(move |_subscriber: Subscriber<O, U>| {
+    loop {
+      // will not complete
+      std::thread::sleep(std::time::Duration::from_secs(1));
+    }
+  })
+}
+
+#[cfg(test)]
+mod test {
+  use crate::prelude::*;
+
+  #[test]
+  fn throw() {
+    let mut value_emitted = false;
+    let mut completed = false;
+    let mut error_emitted = String::new();
+    observable::throw(String::from("error")).subscribe_all(
+      // helping with type inference
+      |_: &i32| value_emitted = true,
+      |e: &String| error_emitted = e.to_string(),
+      || completed = true,
+    );
+    assert!(!value_emitted);
+    assert!(!completed);
+    assert_eq!(error_emitted, "error");
+  }
+
+  #[test]
+  fn empty() {
+    let mut hits = 0;
+    let mut completed = false;
+    observable::empty()
+      .subscribe_complete(|_: &()| hits += 1, || completed = true);
+
+    assert_eq!(hits, 0);
+    assert_eq!(completed, true);
+  }
+}

--- a/src/subscribable.rs
+++ b/src/subscribable.rs
@@ -26,7 +26,7 @@ pub trait IntoShared {
 }
 
 pub trait RawSubscribable<Item, Err, Subscriber> {
-  /// a type implemented [`Subscription`]
+  /// A type implementing [`SubscriptionLike`]
   type Unsub: SubscriptionLike + 'static;
   fn raw_subscribe(self, subscriber: Subscriber) -> Self::Unsub;
 }

--- a/src/subscribable/subscribable_all.rs
+++ b/src/subscribable/subscribable_all.rs
@@ -42,7 +42,7 @@ where
 }
 
 pub trait SubscribableAll<Item, Err, N, E, C> {
-  /// a type implemented [`Subscription`]
+  /// A type implementing [`SubscriptionLike`]
   type Unsub;
 
   /// Invokes an execution of an Observable and registers Observer handlers for

--- a/src/subscribable/subscribable_comp.rs
+++ b/src/subscribable/subscribable_comp.rs
@@ -36,7 +36,7 @@ where
 }
 
 pub trait SubscribableComplete<Item, N, C> {
-  /// a type implemented [`Subscription`]
+  /// A type implementing [`SubscriptionLike`]
   type Unsub;
 
   /// Invokes an execution of an Observable and registers Observer handlers for

--- a/src/subscribable/subscribable_comp.rs
+++ b/src/subscribable/subscribable_comp.rs
@@ -6,7 +6,7 @@ pub struct SubscribeComplete<N, C> {
   complete: C,
 }
 
-impl<Item, N, C> Observer<Item, ()> for SubscribeComplete<N, C>
+impl<Item, Err, N, C> Observer<Item, Err> for SubscribeComplete<N, C>
 where
   N: FnMut(&Item),
   C: FnMut(),
@@ -14,7 +14,7 @@ where
   #[inline(always)]
   fn next(&mut self, value: &Item) { (self.next)(value); }
   #[inline(always)]
-  fn error(&mut self, _err: &()) {}
+  fn error(&mut self, _err: &Err) {}
   #[inline(always)]
   fn complete(&mut self) { (self.complete)(); }
 }

--- a/src/subscribable/subscribable_err.rs
+++ b/src/subscribable/subscribable_err.rs
@@ -34,7 +34,7 @@ where
 }
 
 pub trait SubscribableErr<Item, Err, N, E> {
-  /// a type implemented [`Subscription`]
+  /// A type implementing [`SubscriptionLike`]
   type Unsub;
 
   /// Invokes an execution of an Observable and registers Observer handlers for

--- a/src/subscribable/subscribable_pure.rs
+++ b/src/subscribable/subscribable_pure.rs
@@ -25,7 +25,7 @@ where
 }
 
 pub trait SubscribablePure<Item, N> {
-  /// a type implemented [`Subscription`]
+  /// A type implementing [`SubscriptionLike`]
   type Unsub;
 
   /// Invokes an execution of an Observable and registers Observer handlers for

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -137,8 +137,9 @@ mod test {
     let mut next = 0;
     let mut complete = 0;
 
-    let mut subscriber = Subscriber::local(SubscribeComplete::new(
+    let mut subscriber = Subscriber::local(SubscribeAll::new(
       |_: &_| next += 1,
+      |_: &i32| {},
       || complete += 1,
     ));
 


### PR DESCRIPTION
This MR is about to extend `rxrust` with a set of trivial observables:

never()
from_fn(...) -> AKA start
throw(...)
repeat(...)

as defined on [ReactiveX.io ](http://reactivex.io/documentation/operators.html#categorized) operators.

Also, a trivial observable constructors from Rust-specific `Result<T,E>` and `Option<T>` types:

of_result(...)
of_option(...)

I plan to implement them as functions, therefore the starting point for this MR is the `removing-from-macros` branch (so the diff to master as visible here is not 100% adequate for the time being).
