### PR TITLE
Scan operator fix for #36

### DIFF
--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -246,6 +246,19 @@ mod test {
   }
 
   #[test]
+  fn scan_fork_and_shared_mixed_types() {
+    // type to type can fork
+    let m = observable::from_iter(vec!['a', 'b', 'c']).scan(|acc, v| 1);
+    m.fork()
+      .scan(|acc, v| *v as f32)
+      .fork()
+      .to_shared()
+      .fork()
+      .to_shared()
+      .subscribe(|_| {});
+  }
+
+  #[test]
   fn scan_fork_and_shared() {
     // type to type can fork
     let m = observable::from_iter(0..100).scan(|acc, v| acc + *v);


### PR DESCRIPTION
Fixing the issue with scan operator.
- unit test reproducer added,
- `InputItem` / `OutputItem` type conventions in code of `scan` re-done, to form a clearer pass down the code, leading to correctly composing operators now.

Side change as well: correcting the name of `binary_op` argument in `scan` docstring, 
