### PR TITLE
Adding a set of math and aggregate operators

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
     "rxfn"
-  ]
+  ],
+  "editor.formatOnSave": true,
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 - **operator**: add `scan` operator.
 - **observable**: add trivial `throw`, `empty`, `never` and `repeat` observables.
 - **operator**: add `last` and `last_or` operators.
+- **operator**: add `reduce` and `reduce_initial` operators.
+- **operator**: add `sum`,`min`,`max`,`count` and `average` math/aggregate operators.
 
 ### Bug Fixes
 - **operator**: fix the compiler complain when `map` operator convert source type to a different one.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ license = "MIT"
 futures-preview = "=0.3.0-alpha.18"
 lazy_static = "1.3.0"
 futures-timer = "0.3.0"
+
+[dev-dependencies]
+float-cmp = "0.5.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,9 @@
 #[macro_use]
 extern crate lazy_static;
 
+#[cfg(test)]
+extern crate float_cmp;
+
 pub mod observable;
 pub mod ops;
 pub mod scheduler;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,5 +1,15 @@
 pub mod last;
 pub use last::Last;
+pub mod reduce;
+pub use reduce::Reduce;
+pub mod minmax;
+pub use minmax::MinMax;
+pub mod sum;
+pub use sum::Sum;
+pub mod count;
+pub use count::Count;
+pub mod average;
+pub use average::Average;
 pub mod map;
 pub use map::Map;
 pub mod filter;

--- a/src/ops/average.rs
+++ b/src/ops/average.rs
@@ -1,0 +1,173 @@
+use crate::prelude::*;
+use ops::last::{Last, LastOrOp};
+use ops::map::{Map, MapOp};
+use ops::scan::{Scan, ScanOp};
+use std::ops::Add;
+use std::ops::Mul;
+
+/// Holds intermediate computations of accumulated values for [`Average`]
+/// operator, as nominator and denominator respectively.
+type Accum<Item> = (Item, usize);
+
+/// Computing an average by multiplying accumulated nominator by a reciprocal
+/// of accumulated denominator. In this way some generic types that support
+/// linear scaling over floats values could be averaged (e.g. vectors)
+fn average_floats<T>(acc: &Accum<T>) -> T
+where
+  T: Default + Copy + Send + Mul<f64, Output = T>,
+{
+  // Note: we will never be dividing by zero here, as
+  // the acc.1 will be always >= 1.
+  // It would have be zero if we've would have received an element
+  // when the source observable is empty but beacuse of how
+  // `scan` works, we will transparently not receive anything in
+  // such case.
+  acc.0 * (1.0 / (acc.1 as f64))
+}
+
+fn accumulate_item<T>(acc: &Accum<T>, v: &T) -> Accum<T>
+where
+  T: Copy + Add<T, Output = T>,
+{
+  let newacc = acc.0 + *v;
+  let newcount = acc.1 + 1;
+  (newacc, newcount)
+}
+
+/// Realised as chained composition of scan->last->map operators.
+pub type AverageOp<Source, Item> = MapOp<
+  LastOrOp<
+    ScanOp<Source, fn(&Accum<Item>, &Item) -> Accum<Item>, Item, Accum<Item>>,
+    Accum<Item>,
+  >,
+  fn(&Accum<Item>) -> Item,
+  Accum<Item>,
+>;
+
+pub trait Average<Item>
+where
+  Self: Sized,
+{
+  /// Calculates the sum of numbers emitted by an source observable and emits
+  /// this sum when source completes.
+  ///
+  /// Emits zero when source completed as an and empty sequence.
+  /// Emits error when source observable emits it.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rxrust::prelude::*;
+  /// use rxrust::ops::Average;
+  ///
+  /// observable::from_iter(vec![3., 4., 5., 6., 7.])
+  ///   .average()
+  ///   .subscribe(|v| println!("{}", v));
+  ///
+  /// // print log:
+  /// // 5
+  /// ```
+  ///
+  fn average(self) -> AverageOp<Self, Item>;
+}
+
+/// Implementation for types that scale with multiplying by a f64 value
+/// (e.g f64 numbers itselfs, complex numbers, vectors, matrices).
+impl<O, Item> Average<Item> for O
+where
+  Self: Sized,
+  Item:
+    Copy + Send + Default + Add<Item, Output = Item> + Mul<f64, Output = Item>,
+{
+  fn average(self) -> AverageOp<Self, Item> {
+    // our starting point
+    let start = (Item::default(), 0);
+
+    let acc = accumulate_item as fn(&Accum<Item>, &Item) -> Accum<Item>;
+    let avg = average_floats as fn(&Accum<Item>) -> Item;
+
+    self.scan_initial(start, acc).last().map(avg)
+  }
+}
+
+#[cfg(test)]
+mod test {
+  use crate::{ops::Average, prelude::*};
+  use float_cmp::*;
+
+  #[test]
+  fn average_of_floats() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    let mut num_errors = 0;
+    let mut num_completions = 0;
+    observable::from_iter(vec![3., 4., 5., 6., 7.])
+      .average()
+      .subscribe_all(
+        |v| {
+          num_emissions += 1;
+          emitted = *v
+        },
+        |_| num_errors += 1,
+        || num_completions += 1,
+      );
+    assert!(approx_eq!(f64, 5.0, emitted));
+    assert_eq!(1, num_emissions);
+    assert_eq!(0, num_errors);
+    assert_eq!(1, num_completions);
+  }
+
+  // TODO: this test ideally should be passing, but for now ints have no
+  // default operation of multiplying by f64, so leaving for later
+  // #[test]
+  // fn average_of_ints() {
+  //   let mut emitted = 0.0;
+  //   let mut num_emissions = 0;
+  //   let mut num_errors = 0;
+  //   let mut num_completions = 0;
+  //   observable::from_iter(vec![3, 4, 5, 6, 7])
+  //     .average()
+  //     .subscribe_all(
+  //       |v| {
+  //         num_emissions += 1;
+  //         emitted = *v
+  //       },
+  //       |_| num_errors += 1,
+  //       || num_completions += 1,
+  //     );
+  //   // TODO: never compare floats directly
+  //   assert_eq!(5.0, emitted);
+  //   assert_eq!(1, num_emissions);
+  //   assert_eq!(0, num_errors);
+  //   assert_eq!(1, num_completions);
+  // }
+
+  #[test]
+  fn average_on_single_float_item() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    observable::of(123.0).average().subscribe(|v| {
+      num_emissions += 1;
+      emitted = *v
+    });
+    assert!(approx_eq!(f64, 123.0, emitted));
+    assert_eq!(1, num_emissions);
+  }
+
+  #[test]
+  fn average_on_empty_observable() {
+    let mut emitted: Option<f64> = None;
+    observable::empty()
+      .average()
+      .subscribe(|v| emitted = Some(*v));
+    assert_eq!(None, emitted);
+  }
+
+  #[test]
+
+  fn average_fork_and_shared() {
+    // type to type can fork
+    let m = observable::from_iter(vec![1., 2.]).average();
+    m.fork().to_shared().fork().to_shared().subscribe(|_| {});
+  }
+}

--- a/src/ops/count.rs
+++ b/src/ops/count.rs
@@ -1,0 +1,74 @@
+use crate::prelude::*;
+use ops::reduce::{Reduce, ReduceOp};
+
+pub type CountOp<Source, Item> =
+  ReduceOp<Source, fn(&usize, &Item) -> usize, Item, usize>;
+
+pub trait Count {
+  /// Emits the number of items emitted by a source observable when this source
+  /// completes.
+  ///
+  /// The output type of this operator is fixed to [`usize`].
+  ///
+  /// Emits zero when source completed as an and empty sequence.
+  /// Emits error when source observable emits it.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rxrust::prelude::*;
+  /// use rxrust::ops::Count;
+  ///
+  /// observable::from_iter(vec!['1', '7', '3', '0', '4'])
+  ///   .count()
+  ///   .subscribe(|v| println!("{}", v));
+  ///
+  /// // print log:
+  /// // 5
+  /// ```
+  ///
+  fn count<Item>(self) -> CountOp<Self, Item>
+  where
+    Self: Sized,
+  {
+    self.reduce(|&acc, _v| acc + 1)
+  }
+}
+
+impl<O> Count for O {}
+
+#[cfg(test)]
+mod test {
+  use crate::{ops::Count, prelude::*};
+
+  #[test]
+  fn count() {
+    let mut emitted = 0;
+    observable::from_iter(vec!['1', '7', '3', '0', '4'])
+      .count()
+      .subscribe(|v| emitted = *v);
+    assert_eq!(5, emitted);
+  }
+
+  #[test]
+  fn count_on_empty_observable() {
+    let mut emitted = 0;
+    observable::empty()
+      .count::<i32>()
+      .subscribe(|v| emitted = *v);
+    assert_eq!(0, emitted);
+  }
+
+  #[test]
+  fn count_fork_and_shared() {
+    // type to type can fork
+    let m = observable::from_iter(0..100).count();
+    m.fork()
+      .count()
+      .fork()
+      .to_shared()
+      .fork()
+      .to_shared()
+      .subscribe(|_| {});
+  }
+}

--- a/src/ops/map.rs
+++ b/src/ops/map.rs
@@ -248,6 +248,16 @@ mod test {
       .to_shared()
       .subscribe(|_| {});
 
+    // type mapped to other type can fork
+    let m = observable::from_iter(vec!['a', 'b', 'c']).map(|_v| 1);
+    m.fork()
+      .map(|v| *v as f32)
+      .fork()
+      .to_shared()
+      .fork()
+      .to_shared()
+      .subscribe(|_| {});
+
     // ref to ref can fork
     let m = observable::from_iter(0..100).map_return_ref(|v| v);
     m.fork()
@@ -258,13 +268,13 @@ mod test {
       .to_shared()
       .subscribe(|_| {});
   }
-}
 
-#[test]
-fn map_types_mixed() {
-  let mut i = 0;
-  observable::from_iter(vec!['a', 'b', 'c'])
-    .map(|_v| 1)
-    .subscribe(|v| i += *v);
-  assert_eq!(i, 3);
+  #[test]
+  fn map_types_mixed() {
+    let mut i = 0;
+    observable::from_iter(vec!['a', 'b', 'c'])
+      .map(|_v| 1)
+      .subscribe(|v| i += *v);
+    assert_eq!(i, 3);
+  }
 }

--- a/src/ops/minmax.rs
+++ b/src/ops/minmax.rs
@@ -1,0 +1,268 @@
+use crate::prelude::*;
+use ops::last::{Last, LastOrOp};
+use ops::map::{Map, MapOp};
+use ops::scan::{Scan, ScanOp};
+use std::cmp::PartialOrd;
+use std::option::Option;
+
+/// Realised as chained composition of scan->last->map operators.
+pub type MinMaxOp<Source, Item> = MapOp<
+  LastOrOp<
+    ScanOp<
+      Source,
+      fn(&Option<Item>, &Item) -> Option<Item>,
+      Item,
+      Option<Item>,
+    >,
+    Option<Item>,
+  >,
+  fn(&Option<Item>) -> Item,
+  Option<Item>,
+>;
+
+fn get_greater<Item>(i: &Option<Item>, v: &Item) -> Option<Item>
+where
+  Item: Copy + PartialOrd<Item>,
+{
+  // using universal function call because of name collision with our `map`
+  // being declared in the scope.
+  std::option::Option::map(*i, |vv| if vv < *v { *v } else { vv }).or(Some(*v))
+}
+fn get_lesser<Item>(i: &Option<Item>, v: &Item) -> Option<Item>
+where
+  Item: Copy + PartialOrd<Item>,
+{
+  std::option::Option::map(*i, |vv| if vv > *v { *v } else { vv }).or(Some(*v))
+}
+
+/// Defines `min` and `max` operators for observables.
+pub trait MinMax<Item>
+where
+  Self: Sized,
+{
+  /// Emits the item from the source observable that had the maximum value.
+  ///
+  /// Emits error when source observable emits it.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rxrust::prelude::*;
+  /// use rxrust::ops::MinMax;
+  ///
+  /// observable::from_iter(vec![3., 4., 7., 5., 6.])
+  ///   .max()
+  ///   .subscribe(|v| println!("{}", v));
+  ///
+  /// // print log:
+  /// // 7
+  /// ```
+  ///
+  fn max(self) -> MinMaxOp<Self, Item>
+  where
+    Self: Sized,
+    Item: Copy + Send + PartialOrd<Item>,
+  {
+    let get_greater_func =
+      get_greater as fn(&Option<Item>, &Item) -> Option<Item>;
+
+    self
+      .scan_initial(None, get_greater_func)
+      .last()
+      // we can safely unwrap, because we will ever get this item
+      // once a max value exists and is there.
+      .map(|v| v.unwrap())
+  }
+
+  /// Emits the item from the source observable that had the minimum value.
+  ///
+  /// Emits error when source observable emits it.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rxrust::prelude::*;
+  /// use rxrust::ops::MinMax;
+  ///
+  /// observable::from_iter(vec![3., 4., 7., 5., 6.])
+  ///   .min()
+  ///   .subscribe(|v| println!("{}", v));
+  ///
+  /// // print log:
+  /// // 3
+  /// ```
+  ///
+  fn min(self) -> MinMaxOp<Self, Item>
+  where
+    Self: Sized,
+    Item: Copy + Send + PartialOrd<Item>,
+  {
+    let get_lesser_func =
+      get_lesser as fn(&Option<Item>, &Item) -> Option<Item>;
+
+    self
+      .scan_initial(None, get_lesser_func)
+      .last()
+      // we can safely unwrap, because we will ever get this item
+      // once a max value exists and is there.
+      .map(|v| v.unwrap())
+  }
+}
+
+impl<O, Item> MinMax<Item> for O {}
+
+#[cfg(test)]
+mod test {
+  use crate::{ops::MinMax, prelude::*};
+  use float_cmp::*;
+
+  // -------------------------------------------------------------------
+  // testing Max operator
+  // -------------------------------------------------------------------
+
+  #[test]
+  fn max_of_floats() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    let mut num_errors = 0;
+    let mut num_completions = 0;
+    observable::from_iter(vec![3., 4., 5., 6., 7.])
+      .max()
+      .subscribe_all(
+        |v| {
+          num_emissions += 1;
+          emitted = *v
+        },
+        |_| num_errors += 1,
+        || num_completions += 1,
+      );
+    assert!(approx_eq!(f64, 7.0, emitted));
+    assert_eq!(1, num_emissions);
+    assert_eq!(0, num_errors);
+    assert_eq!(1, num_completions);
+  }
+
+  #[test]
+  fn max_of_floats_negative_values() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    let mut num_errors = 0;
+    let mut num_completions = 0;
+    observable::from_iter(vec![-3., -4., -5., -6., -7.])
+      .max()
+      .subscribe_all(
+        |v| {
+          num_emissions += 1;
+          emitted = *v
+        },
+        |_| num_errors += 1,
+        || num_completions += 1,
+      );
+    assert!(approx_eq!(f64, -3.0, emitted));
+    assert_eq!(1, num_emissions);
+    assert_eq!(0, num_errors);
+    assert_eq!(1, num_completions);
+  }
+
+  #[test]
+  fn max_on_single_float_item() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    observable::of(123.0).max().subscribe(|v| {
+      num_emissions += 1;
+      emitted = *v
+    });
+    assert!(approx_eq!(f64, 123.0, emitted));
+    assert_eq!(1, num_emissions);
+  }
+
+  #[test]
+  fn max_on_empty_observable() {
+    let mut emitted: Option<f64> = None;
+    observable::empty().max().subscribe(|v| emitted = Some(*v));
+    assert_eq!(None, emitted);
+  }
+
+  #[test]
+
+  fn max_fork_and_shared() {
+    // type to type can fork
+    let m = observable::from_iter(vec![1., 2.]).max();
+    m.fork().to_shared().fork().to_shared().subscribe(|_| {});
+  }
+
+  // -------------------------------------------------------------------
+  // testing Min operator
+  // -------------------------------------------------------------------
+
+  #[test]
+  fn min_of_floats() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    let mut num_errors = 0;
+    let mut num_completions = 0;
+    observable::from_iter(vec![3., 4., 5., 6., 7.])
+      .min()
+      .subscribe_all(
+        |v| {
+          num_emissions += 1;
+          emitted = *v
+        },
+        |_| num_errors += 1,
+        || num_completions += 1,
+      );
+    assert!(approx_eq!(f64, 3.0, emitted));
+    assert_eq!(1, num_emissions);
+    assert_eq!(0, num_errors);
+    assert_eq!(1, num_completions);
+  }
+
+  #[test]
+  fn min_of_floats_negative_values() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    let mut num_errors = 0;
+    let mut num_completions = 0;
+    observable::from_iter(vec![-3., -4., -5., -6., -7.])
+      .min()
+      .subscribe_all(
+        |v| {
+          num_emissions += 1;
+          emitted = *v
+        },
+        |_| num_errors += 1,
+        || num_completions += 1,
+      );
+    assert!(approx_eq!(f64, -7.0, emitted));
+    assert_eq!(1, num_emissions);
+    assert_eq!(0, num_errors);
+    assert_eq!(1, num_completions);
+  }
+
+  #[test]
+  fn min_on_single_float_item() {
+    let mut emitted = 0.0;
+    let mut num_emissions = 0;
+    observable::of(123.0).min().subscribe(|v| {
+      num_emissions += 1;
+      emitted = *v
+    });
+    assert!(approx_eq!(f64, 123.0, emitted));
+    assert_eq!(1, num_emissions);
+  }
+
+  #[test]
+  fn min_on_empty_observable() {
+    let mut emitted: Option<f64> = None;
+    observable::empty().min().subscribe(|v| emitted = Some(*v));
+    assert_eq!(None, emitted);
+  }
+
+  #[test]
+
+  fn min_fork_and_shared() {
+    // type to type can fork
+    let m = observable::from_iter(vec![1., 2.]).min();
+    m.fork().to_shared().fork().to_shared().subscribe(|_| {});
+  }
+}

--- a/src/ops/reduce.rs
+++ b/src/ops/reduce.rs
@@ -1,0 +1,154 @@
+use crate::prelude::*;
+use ops::last::{Last, LastOrOp};
+use ops::scan::{Scan, ScanOp};
+
+// A composition of `scan` followed by `last`
+pub type ReduceOp<Source, BinaryOp, InputItem, OutputItem> =
+  LastOrOp<ScanOp<Source, BinaryOp, InputItem, OutputItem>, OutputItem>;
+
+/// The [`Reduce`] operator applies a function to the first item emitted by the
+/// source observable and then feeds the result of the function back into the
+/// function along with the second item emitted by the source observable,
+/// continuing this process until the source observable emits its final item
+/// and completes, whereupon the observable returned from [`Reduce`] emits the
+/// final value returned from the function.
+pub trait Reduce<OutputItem> {
+  /// Apply a function to each item emitted by an observable, sequentially,
+  /// and emit the final value, after source observable completes.
+  ///
+  /// Emits error when source observable emits it.
+  ///
+  /// # Arguments
+  ///
+  /// * `initial` - An initial value to start the successive reduction from.
+  /// * `binary_op` - A closure acting as a binary (folding) operator.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rxrust::prelude::*;
+  /// use rxrust::ops::Reduce;
+  ///
+  /// observable::from_iter(vec![1, 1, 1, 1, 1])
+  ///   .reduce_initial(100, |acc, v| acc + v)
+  ///   .subscribe(|v| println!("{}", v));
+  ///
+  /// // print log:
+  /// // 105
+  /// ```
+  ///
+  fn reduce_initial<InputItem, BinaryOp>(
+    self,
+    initial: OutputItem,
+    binary_op: BinaryOp,
+  ) -> ReduceOp<Self, BinaryOp, InputItem, OutputItem>
+  where
+    Self: Sized,
+    BinaryOp: Fn(&OutputItem, &InputItem) -> OutputItem,
+    OutputItem: Clone,
+  {
+    // realised as a composition of `scan`, and `last`
+    self
+      .scan_initial(initial.clone(), binary_op)
+      .last_or(initial)
+  }
+
+  /// Works like [`reduce_initial`] but starts with a value defined by a
+  /// [`Default`] trait for the first argument `f` operator operates on.
+  ///
+  /// # Arguments
+  ///
+  /// * `binary_op` - A closure acting as a binary operator.
+  ///
+  fn reduce<InputItem, BinaryOp>(
+    self,
+    binary_op: BinaryOp,
+  ) -> LastOrOp<ScanOp<Self, BinaryOp, InputItem, OutputItem>, OutputItem>
+  where
+    Self: Sized,
+    BinaryOp: Fn(&OutputItem, &InputItem) -> OutputItem,
+    OutputItem: Default + Clone,
+  {
+    self.reduce_initial(OutputItem::default(), binary_op)
+  }
+}
+
+impl<O, OutputItem> Reduce<OutputItem> for O {}
+
+#[cfg(test)]
+mod test {
+  use crate::{ops::Reduce, prelude::*};
+
+  #[test]
+  fn reduce_initial() {
+    let mut emitted = 0;
+    observable::from_iter(vec![1, 1, 1, 1, 1])
+      .reduce_initial(100, |acc, v| acc + v)
+      .subscribe(|v| emitted = *v);
+
+    assert_eq!(105, emitted);
+  }
+
+  #[test]
+  fn reduce_initial_on_empty_observable() {
+    let mut emitted = 0;
+    observable::empty()
+      .reduce_initial(100, |acc, v| acc + v)
+      .subscribe(|v| emitted = *v);
+
+    // expected to emit the initial value
+    assert_eq!(100, emitted);
+  }
+  #[test]
+  fn reduce() {
+    let mut emitted = 0;
+    observable::from_iter(vec![1, 1, 1, 1, 1])
+      .reduce(|acc, v| acc + v)
+      .subscribe(|v| emitted = *v);
+
+    assert_eq!(5, emitted);
+  }
+
+  #[test]
+  fn reduce_on_empty_observable() {
+    let mut emitted = 0;
+    observable::empty()
+      .reduce(|acc, v| acc + v)
+      .subscribe(|v| emitted = *v);
+
+    assert_eq!(0, emitted);
+  }
+
+  #[test]
+  fn reduce_mixed_types() {
+    // we're using mixed numeric types here to perform transform
+    let mut emitted = 0u32;
+    observable::from_iter(vec![1i32, 2i32, 3i32, 4i32])
+      .reduce(|acc, v: &i32| acc + (*v as u32))
+      .subscribe(|v| emitted = *v);
+
+    assert_eq!(10u32, emitted);
+  }
+  #[test]
+  fn reduce_for_counting_total_length() {
+    let mut emitted = 0;
+    observable::from_iter(vec![String::from("foo"), String::from("bar")])
+      .reduce(|acc, v: &String| acc + v.len())
+      .subscribe(|v| emitted = *v);
+
+    assert_eq!(6, emitted);
+  }
+
+  #[test]
+  fn reduce_fork_and_shared() {
+    // type to type can fork
+    let m = observable::from_iter(0..100).reduce(|acc, v| acc + *v);
+    m.fork()
+      .reduce(|acc, v| acc + *v)
+      .fork()
+      .to_shared()
+      .fork()
+      .to_shared()
+      .subscribe(|_| {});
+  }
+}

--- a/src/ops/scan.rs
+++ b/src/ops/scan.rs
@@ -220,6 +220,16 @@ mod test {
 
     assert_eq!(vec!(101, 102, 103, 104, 105), emitted);
   }
+  #[test]
+  fn scan_initial_on_empty_observable() {
+    let mut emitted = Vec::<i32>::new();
+    // should work like accumulate from 100
+    observable::empty()
+      .scan_initial(100, |acc, v| acc + v)
+      .subscribe(|v| emitted.push(*v));
+
+    assert_eq!(Vec::<i32>::new(), emitted);
+  }
 
   #[test]
   fn scan_initial_mixed_types() {

--- a/src/ops/sum.rs
+++ b/src/ops/sum.rs
@@ -1,0 +1,88 @@
+use crate::prelude::*;
+use ops::reduce::{Reduce, ReduceOp};
+use std::ops::Add;
+
+pub type SumOp<Source, Item> =
+  ReduceOp<Source, fn(&Item, &Item) -> Item, Item, Item>;
+
+pub trait Sum<Item> {
+  /// Calculates the sum of numbers emitted by an source observable and emits
+  /// this sum when source completes.
+  ///
+  /// Emits zero when source completed as an and empty sequence.
+  /// Emits error when source observable emits it.
+  ///
+  /// # Examples
+  ///
+  /// ```
+  /// use rxrust::prelude::*;
+  /// use rxrust::ops::Sum;
+  ///
+  /// observable::from_iter(vec![1, 1, 1, 1, 1])
+  ///   .sum()
+  ///   .subscribe(|v| println!("{}", v));
+  ///
+  /// // print log:
+  /// // 5
+  /// ```
+  ///
+  fn sum(self) -> SumOp<Self, Item>
+  where
+    Self: Sized,
+    Item: Copy + Default + Add<Item, Output = Item>,
+  {
+    self.reduce(|&acc, &v| acc + v)
+  }
+}
+
+impl<O, Item> Sum<Item> for O {}
+
+#[cfg(test)]
+mod test {
+  use crate::{ops::Sum, prelude::*};
+
+  #[test]
+  fn sum() {
+    let mut emitted = 0;
+    observable::from_iter(vec![1, 1, 1, 1, 1])
+      .sum()
+      .subscribe(|v| emitted = *v);
+    assert_eq!(5, emitted);
+  }
+
+  #[test]
+  fn sum_on_single_item() {
+    let mut emitted = 0;
+    observable::of(123).sum().subscribe(|v| emitted = *v);
+    assert_eq!(123, emitted);
+  }
+
+  #[test]
+  fn sum_on_empty_observable() {
+    let mut emitted = 0;
+    observable::empty().sum().subscribe(|v| emitted = *v);
+    assert_eq!(0, emitted);
+  }
+
+  #[test]
+  fn sum_on_mixed_sign_values() {
+    let mut emitted = 0;
+    observable::from_iter(vec![1, -1, 1, -1, -1])
+      .sum()
+      .subscribe(|v| emitted = *v);
+    assert_eq!(-1, emitted);
+  }
+
+  #[test]
+  fn sum_fork_and_shared() {
+    // type to type can fork
+    let m = observable::from_iter(0..100).sum();
+    m.fork()
+      .sum()
+      .fork()
+      .to_shared()
+      .fork()
+      .to_shared()
+      .subscribe(|_| {});
+  }
+}


### PR DESCRIPTION
This PR aims to provide a collection of Mathematical and Aggregate Operators operators:

- [x] reduce
- [x] sum
- [x] count
- [x] average
- [x] min
- [x] max

They are mainly implemented indirectly as a composition of already existing ones like scan/last/map etc for few reasons:
- Rust should nicely optimise out all the boilerplate and result with still lean and performant code after compilation,
- we reduce a boilerplate code of plumbing things together in a similar way,
- it's a nice challenge to existing operators and how they compose, so potentially will reveal their weak points early.


Work in progress...