### PR TITLE
use a longer duration to let the unit test more reliable

### DIFF
--- a/.github/workflows/lint_and_test.yml
+++ b/.github/workflows/lint_and_test.yml
@@ -17,6 +17,8 @@ jobs:
       run: |
         rustup component add clippy
         cargo clippy --all-targets --all-features -- -D warnings
+    - name: build
+      run: cargo build
     - name: test
       run: cargo test --all
     - name: bench

--- a/src/observable/interval.rs
+++ b/src/observable/interval.rs
@@ -79,10 +79,10 @@ fn smoke() {
   use std::sync::{Arc, Mutex};
   let seconds = Arc::new(Mutex::new(0));
   let c_seconds = seconds.clone();
-  interval!(Duration::from_millis(10)).subscribe(move |_| {
+  interval!(Duration::from_millis(20)).subscribe(move |_| {
     *seconds.lock().unwrap() += 1;
   });
-  std::thread::sleep(Duration::from_millis(55));
+  std::thread::sleep(Duration::from_millis(110));
   assert_eq!(*c_seconds.lock().unwrap(), 5);
 }
 

--- a/src/ops/throttle_time.rs
+++ b/src/ops/throttle_time.rs
@@ -185,19 +185,19 @@ fn smoke() {
   let x = Arc::new(Mutex::new(vec![]));
   let x_c = x.clone();
 
-  let interval = observable::interval!(Duration::from_millis(2));
+  let interval = observable::interval!(Duration::from_millis(5));
   let throttle_subscribe = |edge| {
     let x = x.clone();
     interval
       .fork()
       .to_shared()
-      .throttle_time(Duration::from_millis(19), edge)
+      .throttle_time(Duration::from_millis(48), edge)
       .subscribe(move |v| x.lock().unwrap().push(*v))
   };
 
   // tailing throttle
   let mut sub = throttle_subscribe(ThrottleEdge::Tailing);
-  std::thread::sleep(Duration::from_millis(205));
+  std::thread::sleep(Duration::from_millis(520));
   sub.unsubscribe();
   assert_eq!(
     x_c.lock().unwrap().clone(),
@@ -207,7 +207,7 @@ fn smoke() {
   // leading throttle
   x_c.lock().unwrap().clear();
   throttle_subscribe(ThrottleEdge::Leading);
-  std::thread::sleep(Duration::from_millis(205));
+  std::thread::sleep(Duration::from_millis(520));
   assert_eq!(
     x_c.lock().unwrap().clone(),
     vec![0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]

--- a/src/subject.rs
+++ b/src/subject.rs
@@ -271,7 +271,7 @@ mod test {
     );
 
     subject.next(&100);
-    std::thread::sleep(std::time::Duration::from_micros(1));
+    std::thread::sleep(std::time::Duration::from_millis(1));
 
     assert_eq!(*c_v.lock().unwrap(), 100);
   }


### PR DESCRIPTION
before we have a virtual timer, we can use a longer duration to let the unit test more reliable